### PR TITLE
[codex] Add Koutian Wu blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ USTCLUG 同学们的博客列表，参考了 TUNA 协会的 [blogroll](https://g
 | cuihao (cvhc)  | https://blog.cvhc.cc/            |                                          |
 | jenny42        | https://jenny42.com/             | https://jenny42.com/atom.xml             |
 | GWDx           | https://gwdx.github.io/          | https://gwdx.github.io/index.xml         |
+| Koutian Wu     | https://koutian.is-a.dev/        | https://koutian.is-a.dev/feed.xml        |
 
 ## OPML 文件
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ USTCLUG 同学们的博客列表，参考了 TUNA 协会的 [blogroll](https://g
 | cuihao (cvhc)  | https://blog.cvhc.cc/            |                                          |
 | jenny42        | https://jenny42.com/             | https://jenny42.com/atom.xml             |
 | GWDx           | https://gwdx.github.io/          | https://gwdx.github.io/index.xml         |
-| Koutian Wu     | https://koutian.is-a.dev/        | https://koutian.is-a.dev/feed.xml        |
+| Koutian Wu     | https://ktwu01.github.io        | https://ktwu01.github.io/feed.xml       |
 
 ## OPML 文件
 


### PR DESCRIPTION
## Summary
- Add Koutian Wu's personal academic blog to the USTCLUG blog list.
- Include the live Atom feed URL so it appears in generated OPML output.

## Validation
- `python3 opml.py --output /tmp/ustclug.opml`
- Verified `https://ktwu01.github.io/` and `https://ktwu01.github.io/feed.xml` return HTTP 200.
